### PR TITLE
Adding new SKU Mellanox-SN4600C-C4

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers.json.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers.json.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
@@ -1,0 +1,112 @@
+{% set default_cable = '5m' %}
+{% set ingress_lossless_pool_size =  '53379072' %}
+{% set ingress_lossy_pool_size =  '1540096' %}
+{% set egress_lossless_pool_size =  '60817408' %}
+{% set egress_lossy_pool_size =  '53379072' %}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0, 32) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ ingress_lossless_pool_size }}",
+            {%- endif %}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "ingress_lossy_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ ingress_lossy_pool_size }}",
+            {%- endif %}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "{{ egress_lossless_pool_size }}",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ egress_lossy_pool_size }}",
+            {%- endif %}
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_profile_lists(port_names) %}
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+{% for port in port_names.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+{% for port in port_names.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_queue_buffers(port_names) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
@@ -1,0 +1,112 @@
+{% set default_cable = '5m' %}
+{% set ingress_lossless_pool_size =  '52723712' %}
+{% set ingress_lossless_pool_xoff =  '2195456' %}
+{% set egress_lossless_pool_size =  '60817408' %}
+{% set egress_lossy_pool_size =  '52723712' %}
+
+{%- macro generate_port_lists(PORT_ALL) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(0, 32) %}
+        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ ingress_lossless_pool_size }}",
+            {%- endif %}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "ingress_lossy_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ ingress_lossy_pool_size }}",
+            {%- endif %}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "{{ egress_lossless_pool_size }}",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            {%- if dynamic_mode is not defined %}
+            "size": "{{ egress_lossy_pool_size }}",
+            {%- endif %}
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_profile_lists(port_names) %}
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+{% for port in port_names.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+{% for port in port_names.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_queue_buffers(port_names) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+{% endfor %}
+{% for port in port_names.split(',') %}
+        "{{ port }}|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_dynamic.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_dynamic.json.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_dynamic.json.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/hwsku.json
@@ -1,0 +1,196 @@
+{
+    "interfaces": {
+        "Ethernet0": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet8": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet16": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet24": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet32": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet40": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet48": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet56": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet64": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet72": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet80": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet88": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet96": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet104": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet112": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet120": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet128": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet136": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet144": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet152": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet160": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet168": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet176": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet184": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet192": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet200": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet208": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet216": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet224": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet232": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet240": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet248": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet256": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet264": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet272": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet280": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet288": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet296": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet304": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet312": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet320": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet328": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet336": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet344": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet352": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet360": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet368": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet376": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet384": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet392": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet400": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet408": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet416": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet424": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet432": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet440": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet448": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet456": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet464": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet472": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet480": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet488": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet496": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }, 
+        "Ethernet504": {
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/pg_profile_lookup.ini
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/pg_profile_lookup.ini
@@ -1,0 +1,1 @@
+../Mellanox-SN4600C-D112C8/pg_profile_lookup.ini

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/port_config.ini
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/port_config.ini
@@ -1,0 +1,1 @@
+../ACS-MSN4600C/port_config.ini

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/qos.json.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/qos.json.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai.profile
@@ -1,0 +1,2 @@
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/sai_4600C.xml
+SAI_VXLAN_SRCPORT_RANGE_ENABLE=1

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai_4600C.xml
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/sai_4600C.xml
@@ -1,0 +1,1 @@
+../ACS-MSN4600C/sai_4600C.xml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I did it to add a new SKU Mellanox-SN4600c-c64

#### How I did it
I developed the SKU based on SKU definitions with the following requirements and tested it on Mellanox 4600C switch.

Port configuration:
• Breakout mode for each port: No
• Speed of the port: 100G
• Auto-negotiation enable/disable: No setting required
• FEC mode: No setting required
• Type of transceiver used: Not needed

Buffer configuration
• Shared headroom enable 
• If shared headroom enabled what is the over-subscription ratio as in SN3800
• Dynamic Buffer disable
• In static buffer scenario how many uplinks and downlinks? as in SN3800
• 2km cable support required? no

Switch configuration
• Warmboot enabled? yes
• Should warmboot be added to SAI profile when enabled? yes
• Is VxLAN source port range set? yes
• Should Vxlan source port range be added to SAI profile when set. as in SN3800
• Is Static Policy Based Hashing enabled? no

Number of Uplinks/Downlinks:
  - t0: 32 100G down links and 32 100G up links.
  - t1: 56 100G down links and 8 100G up links.

#### How to verify it
Set the SKU in config_db.json to Mellanox-SN4600C-C64 and test the 100G ports coming up on the switch.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changes are in sonic-buildimage/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/ folder.

#### A picture of a cute animal (not mandatory but encouraged)

